### PR TITLE
Fix unused variable TypeScript error in build

### DIFF
--- a/src/sprites/registry.ts
+++ b/src/sprites/registry.ts
@@ -144,11 +144,6 @@ class SpriteRegistry {
     });
   }
 
-  private getPlaceholderSprite(): string {
-    // TODO: Create a generic placeholder sprite
-    return `${this.baseUrl}/placeholder.gif`;
-  }
-
   private capitalize(str: string): string {
     return str.charAt(0).toUpperCase() + str.slice(1);
   }


### PR DESCRIPTION
Remove the unused getPlaceholderSprite() method from SpriteRegistry to fix TypeScript compilation error TS6133. The function was a TODO placeholder that was never implemented or called.

This resolves the Netlify build failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code cleanup with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->